### PR TITLE
Pokedex list remotedata

### DIFF
--- a/app/src/main/java/com/rafael/mardom/app/data/ApiCallResponseExt.kt
+++ b/app/src/main/java/com/rafael/mardom/app/data/ApiCallResponseExt.kt
@@ -1,0 +1,28 @@
+package com.rafael.mardom.app.data
+
+import com.rafael.mardom.app.domain.ErrorApp
+import com.rafael.mardom.app.domain.functional.Either
+import com.rafael.mardom.app.domain.functional.left
+import com.rafael.mardom.app.domain.functional.right
+import retrofit2.Response
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+suspend fun <T : Any> apiCall(call: suspend () -> Response<T>): Either<ErrorApp, T> {
+    val response: Response<T>
+    try {
+        response = call.invoke()
+    } catch (exception: Throwable) {
+        return when (exception) {
+            is ConnectException -> ErrorApp.NoInternetError.left()
+            is UnknownHostException -> ErrorApp.NoInternetError.left()
+            is SocketTimeoutException -> ErrorApp.TimeOutError.left()
+            else -> ErrorApp.UnknownError.left()
+        }
+    }
+    if (!response.isSuccessful) {
+        return ErrorApp.UnknownError.left()
+    }
+    return response.body()!!.right()
+}

--- a/app/src/main/java/com/rafael/mardom/app/di/RemoteDataModule.kt
+++ b/app/src/main/java/com/rafael/mardom/app/di/RemoteDataModule.kt
@@ -1,0 +1,24 @@
+package com.rafael.mardom.app.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RemoteDataModule {
+
+    private const val BASE_URL = "https://pokeapi.co/api/v2/"
+
+    @Singleton
+    @Provides
+    fun provideRetrofit(): Retrofit = Retrofit.Builder()
+        .addConverterFactory(GsonConverterFactory.create())
+        .baseUrl(BASE_URL)
+        .build()
+
+}

--- a/app/src/main/java/com/rafael/mardom/app/domain/ErrorApp.kt
+++ b/app/src/main/java/com/rafael/mardom/app/domain/ErrorApp.kt
@@ -3,4 +3,6 @@ package com.rafael.mardom.app.domain
 sealed class ErrorApp {
     object DataError : ErrorApp()
     object NoInternetError : ErrorApp()
+    object TimeOutError : ErrorApp()
+    object UnknownError : ErrorApp()
 }

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/PokemonDataRepository.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/PokemonDataRepository.kt
@@ -2,15 +2,21 @@ package com.rafael.mardom.features.pokedex.data
 
 import com.rafael.mardom.app.domain.ErrorApp
 import com.rafael.mardom.app.domain.functional.Either
+import com.rafael.mardom.app.domain.functional.left
+import com.rafael.mardom.features.pokedex.data.remote.PokemonRemoteDataSource
 import com.rafael.mardom.features.pokedex.domain.Pokemon
 import com.rafael.mardom.features.pokedex.domain.PokemonRepository
 import javax.inject.Inject
 
 class PokemonDataRepository @Inject constructor(
     // private val localDataSource: PokemonLocalDataSource, // Será añadido en el futuro
-    // private val remoteDataSource: PokemonRemoteDataSource
+    private val remoteDataSource: PokemonRemoteDataSource
 ) : PokemonRepository {
     override suspend fun getAll(): Either<ErrorApp, List<Pokemon>> {
-        TODO("Not yet implemented")
+        return try {
+            remoteDataSource.getAll()
+        }catch (e: java.lang.Exception){
+            return ErrorApp.DataError.left()
+        }
     }
 }

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/PokemonDataRepository.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/PokemonDataRepository.kt
@@ -1,0 +1,16 @@
+package com.rafael.mardom.features.pokedex.data
+
+import com.rafael.mardom.app.domain.ErrorApp
+import com.rafael.mardom.app.domain.functional.Either
+import com.rafael.mardom.features.pokedex.domain.Pokemon
+import com.rafael.mardom.features.pokedex.domain.PokemonRepository
+import javax.inject.Inject
+
+class PokemonDataRepository @Inject constructor(
+    // private val localDataSource: PokemonLocalDataSource, // Será añadido en el futuro
+    // private val remoteDataSource: PokemonRemoteDataSource
+) : PokemonRepository {
+    override suspend fun getAll(): Either<ErrorApp, List<Pokemon>> {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/PokemonRemoteDataSource.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/PokemonRemoteDataSource.kt
@@ -1,0 +1,9 @@
+package com.rafael.mardom.features.pokedex.data.remote
+
+import com.rafael.mardom.app.domain.ErrorApp
+import com.rafael.mardom.app.domain.functional.Either
+import com.rafael.mardom.features.pokedex.domain.Pokemon
+
+interface PokemonRemoteDataSource {
+    suspend fun getAll(): Either<ErrorApp, List<Pokemon>>
+}

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/ApiEndPoints.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/ApiEndPoints.kt
@@ -1,0 +1,14 @@
+package com.rafael.mardom.features.pokedex.data.remote.api
+
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface ApiEndPoints {
+
+    @GET("pokemon/{id}")
+    suspend fun getPokemonById(@Path("id") id: Int): Response<PokemonApiModel>
+    @GET("pokemon-species/{id}")
+    suspend fun getPokemonEntryById(@Path("id") id: Int): Response<PokemonEntryApiModel>
+
+}

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/ApiMapper.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/ApiMapper.kt
@@ -1,0 +1,33 @@
+package com.rafael.mardom.features.pokedex.data.remote.api
+
+import com.rafael.mardom.features.pokedex.domain.Pokemon
+import com.rafael.mardom.features.pokedex.domain.PokemonSprite
+import com.rafael.mardom.features.pokedex.domain.PokemonStats
+
+fun PokemonApiModel.toDomain() = Pokemon(
+    id = this.id,
+    name = this.name,
+    description = this.description[0].toDomain(),
+    height = this.height,
+    weight = this.weight,
+    types = this.types.map {
+        it.toDomain()
+    },
+    stats = this.stats.map {
+        it.toDomain()
+    },
+    sprites = this.sprites.toDomain()
+)
+
+private fun PokemonEntryApiModel.toDomain(): String = this.entry[0].description
+private fun PokemonTypesApiModel.toDomain(): String = this.type.name
+private fun PokemonStatsApiModel.toDomain() = PokemonStats(
+    name = this.stat.name,
+    base = this.base
+)
+private fun PokemonSpriteApiModel.toDomain() = PokemonSprite(
+    front_default = this.front_default,
+    front_shiny = this.front_shiny,
+    back_default = this.back_default,
+    back_shiny = this.back_shiny,
+)

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/ApiMapper.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/ApiMapper.kt
@@ -4,10 +4,10 @@ import com.rafael.mardom.features.pokedex.domain.Pokemon
 import com.rafael.mardom.features.pokedex.domain.PokemonSprite
 import com.rafael.mardom.features.pokedex.domain.PokemonStats
 
-fun PokemonApiModel.toDomain() = Pokemon(
+fun PokemonApiModel.toDomain(description: PokemonEntryApiModel) = Pokemon(
     id = this.id,
     name = this.name,
-    description = this.description[0].toDomain(),
+    description = description.toDomain(),
     height = this.height,
     weight = this.weight,
     types = this.types.map {

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/ApiModels.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/ApiModels.kt
@@ -1,0 +1,46 @@
+package com.rafael.mardom.features.pokedex.data.remote.api
+
+import com.google.gson.annotations.SerializedName
+
+data class PokemonApiModel(
+    @SerializedName("id") val id: Int,
+    @SerializedName("name") val name: String,
+    @SerializedName("species") val description: List<PokemonEntryApiModel>,
+    @SerializedName("height") val height: Double,
+    @SerializedName("weight") val weight: Double,
+    @SerializedName("types") val types: List<PokemonTypesApiModel>,
+    @SerializedName("stats") val stats: List<PokemonStatsApiModel>,
+    @SerializedName("sprites") val sprites: PokemonSpriteApiModel,
+)
+
+data class PokemonEntryApiModel(
+    @SerializedName("flavor_text_entries") val entry: List<EntryApiModel>
+)
+
+data class EntryApiModel(
+    @SerializedName("flavor_text") val description: String
+)
+
+data class PokemonTypesApiModel(
+    @SerializedName("type") val type: TypeApiModel
+)
+
+data class TypeApiModel(
+    @SerializedName("name") val name: String
+)
+
+data class PokemonStatsApiModel(
+    @SerializedName("stat") val stat: StatApiModel,
+    @SerializedName("base_stat") val base: Int
+)
+
+data class StatApiModel(
+    @SerializedName("name") val name: String
+)
+
+data class PokemonSpriteApiModel(
+    @SerializedName("front_default") val front_default: String,
+    @SerializedName("front_shiny") val front_shiny: String,
+    @SerializedName("back_default") val back_default: String,
+    @SerializedName("back_shiny") val back_shiny: String,
+)

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/ApiModels.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/ApiModels.kt
@@ -5,7 +5,6 @@ import com.google.gson.annotations.SerializedName
 data class PokemonApiModel(
     @SerializedName("id") val id: Int,
     @SerializedName("name") val name: String,
-    @SerializedName("species") val description: List<PokemonEntryApiModel>,
     @SerializedName("height") val height: Double,
     @SerializedName("weight") val weight: Double,
     @SerializedName("types") val types: List<PokemonTypesApiModel>,

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/PokemonApiRemoteDataSource.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/PokemonApiRemoteDataSource.kt
@@ -1,0 +1,59 @@
+package com.rafael.mardom.features.pokedex.data.remote.api
+
+import android.util.Log
+import com.rafael.mardom.app.data.apiCall
+import com.rafael.mardom.app.domain.ErrorApp
+import com.rafael.mardom.app.domain.functional.Either
+import com.rafael.mardom.app.domain.functional.left
+import com.rafael.mardom.app.domain.functional.right
+import com.rafael.mardom.features.pokedex.data.remote.PokemonRemoteDataSource
+import com.rafael.mardom.features.pokedex.domain.Pokemon
+import javax.inject.Inject
+
+class PokemonApiRemoteDataSource @Inject constructor(
+    private val apiClient: ApiEndPoints
+) : PokemonRemoteDataSource {
+
+    private val pokemonNumber: Int = 151
+
+    override suspend fun getAll(): Either<ErrorApp, List<Pokemon>> {
+        val pokedex = mutableListOf<Pokemon>()
+        return try {
+            for (num in 1..pokemonNumber) {
+                Log.d("@dev", "$num")
+                val pokemon = getById(num).get()
+                pokedex.add(pokemon)
+            }
+            return pokedex.right()
+        } catch (e: java.lang.Exception) {
+            ErrorApp.DataError.left()
+        }
+    }
+
+    private suspend fun getById(id: Int): Either<ErrorApp, Pokemon> {
+        return try {
+            apiCall {
+                apiClient.getPokemonById(id)
+            }.fold(
+                {
+                    it.left()
+                },
+                {
+                    val pokemonDescription = getPokemonDescription(id).get()
+                    it.toDomain(pokemonDescription).right()
+                })
+        } catch (e: java.lang.Exception) {
+            return ErrorApp.DataError.left()
+        }
+    }
+
+    private suspend fun getPokemonDescription(id: Int): Either<ErrorApp, PokemonEntryApiModel> {
+        return try {
+            apiCall {
+                apiClient.getPokemonEntryById(id)
+            }.get().right()
+        } catch (e: java.lang.Exception) {
+            return ErrorApp.DataError.left()
+        }
+    }
+}

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/PokemonApiRemoteDataSource.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/remote/api/PokemonApiRemoteDataSource.kt
@@ -1,6 +1,5 @@
 package com.rafael.mardom.features.pokedex.data.remote.api
 
-import android.util.Log
 import com.rafael.mardom.app.data.apiCall
 import com.rafael.mardom.app.domain.ErrorApp
 import com.rafael.mardom.app.domain.functional.Either
@@ -20,7 +19,6 @@ class PokemonApiRemoteDataSource @Inject constructor(
         val pokedex = mutableListOf<Pokemon>()
         return try {
             for (num in 1..pokemonNumber) {
-                Log.d("@dev", "$num")
                 val pokemon = getById(num).get()
                 pokedex.add(pokemon)
             }

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/di/PokemonModule.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/di/PokemonModule.kt
@@ -1,0 +1,22 @@
+package com.rafael.mardom.features.pokedex.di
+
+import com.rafael.mardom.features.pokedex.data.PokemonDataRepository
+import com.rafael.mardom.features.pokedex.data.remote.PokemonRemoteDataSource
+import com.rafael.mardom.features.pokedex.data.remote.api.PokemonApiRemoteDataSource
+import com.rafael.mardom.features.pokedex.domain.PokemonRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+
+@Module
+@InstallIn(ViewModelComponent::class)
+abstract class PokemonModule {
+
+    @Binds
+    abstract fun bindPokemonRepository(repository: PokemonDataRepository): PokemonRepository
+
+    @Binds
+    abstract fun bindPokemonRemoteApiDataSource(remoteSource: PokemonApiRemoteDataSource): PokemonRemoteDataSource
+
+}

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/di/PokemonProvidesModule.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/di/PokemonProvidesModule.kt
@@ -1,0 +1,20 @@
+package com.rafael.mardom.features.pokedex.di
+
+import com.rafael.mardom.features.pokedex.data.remote.api.ApiEndPoints
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PokemonProvidesModule {
+
+    @Singleton
+    @Provides
+    fun providesPokemonApiEndPoints(retrofit: Retrofit) : ApiEndPoints =
+        retrofit.create(ApiEndPoints::class.java)
+
+}


### PR DESCRIPTION
## Descripción
Deberemos recoger información de los Pokemon recibiendo los datos de una API externa.
Al ser esta la primera toma de contacto con la capa de datos, se creará en esta iteración las clases comunes necesarias para todas las funcionalidades relacionadas, no solo los datos remotos.

## ¿Cómo se ha implementado?
Se han creado multitud de ficheros referentes al acceso a datos en remoto, así como las clases e interfaces para tratarlos.

En primer lugar, en la cada de features/pokedex/data se ha creado una estructura de carpetas y archivos referente a la capa de Data.

- `PokemonDataRepository`: Es la clase que tratará los datos en la app. Primero se obtienen datos de remoto, luego son guardados en almacenamiento local y desde entonces, se trabajará con la base de datos local para evitar llamadas repetitivas a la API.
- remote/`PokemonRemoteDataSource`: Es la interfaz que recoge las funciones que deberán implementar la clase que recoja los datos de la API.
- remote/api/`ApiModels`: Recoge las data class referentes a la información recogida desde la API.
- remote/api/`ApiMapper`: Archivo con funciones de extensión que permiten parsear los datos de la manera en que son recibidos de remoto (ApiModel) a la forma con la que trabajaremos en la app (DomainModel, data classes en el fichero Models.kt de domain).

A continuación, ahora en diversos puntos de la organización del proyecto, se han creado ficheros para la conexión a la API. Para su implementación, se ha optado por la librería Retrofit y un patrón Singleton.

- app/data/di/`RemoteDataModule`: Clase donde se crea la función que devuelve un objeto Retrofit con la conexión a la API mediante un Singleton.

- features/pokedex/data/remote/api/`ApiEndPoints`: En este fichero, mediante las etiquetas de Retrofit, especificamos las llamadas a la API y los datos que devuelven, que serán recogidos en base a los ApiModels.

- features/pokedex/di/`PokemonProvidesModule`: Objeto con el Provide del ApiEndPoints necesario para la conexión con la api.

Las clases con las funciones necesarias para la gestión y obtención de los datos son las siguientes:

- app/data/`ApiCallResponseExt`: En este fichero se ha creado una función de extensión común para toda la app que abstrae la respuesta de la API, utilizando objetos genéricos para ser utilizada independientemente del objeto que reciba por respuesta, ya que para la correcta obtención de datos, hacemos llamadas a dos rutas de la API distintas.

- feature/data/remote/api/`PokemonApiRemoteDataSource`: Clase donde se realizan las llamadas a la API y se gestiona la recolección de datos. Aquí es donde se encuentra la concreción de las funciones que hereda de `PokemonRemoteDataSource`. Aquí se utiliza la función creada en el fichero `ApiCallResponseExt`.

## Pruebas
Para comprobar que se recogen los datos correctamente, se ha creado por adelantado la clase abstracta `PokemonModule`, que va a recoger los binding correspondientes entre clases de Data y la clase de presentación donde se llamará a las funciones. A falta de no tener este apartado (Presentation), se ha hecho una ñapa en MainActivity y mediante debugging comprobamos que se reciben los datos correctamente.

## Screenshots or Video
> Pruebas Realizadas

![image](https://user-images.githubusercontent.com/104196849/227885439-e71b6cd8-ae17-4151-884c-e44c2864c7d4.png)

![image](https://user-images.githubusercontent.com/104196849/227885323-d8ee6ea5-a044-476b-a5ac-8a1f29ee9481.png)

![image](https://user-images.githubusercontent.com/104196849/227884746-64bf580e-1404-49e8-8882-72bf73799203.png)

