### PR TITLE
Pokedex list localdata

### DIFF
--- a/app/src/main/java/com/rafael/mardom/app/data/db/AppDataBase.kt
+++ b/app/src/main/java/com/rafael/mardom/app/data/db/AppDataBase.kt
@@ -1,0 +1,24 @@
+package com.rafael.mardom.app.data.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.rafael.mardom.BuildConfig
+import com.rafael.mardom.features.pokedex.data.local.db.PokemonDao
+import com.rafael.mardom.features.pokedex.data.local.db.PokemonEntity
+import com.rafael.mardom.features.pokedex.data.local.db.PokemonSpriteEntity
+import com.rafael.mardom.features.pokedex.data.local.db.PokemonStatsEntity
+
+@Database(
+    entities = [
+        PokemonEntity::class,
+        PokemonStatsEntity::class,
+        PokemonSpriteEntity::class,
+    ],
+    version = BuildConfig.VERSION_CODE,
+    exportSchema = false
+)
+@TypeConverters(DbConverters::class)
+abstract class AppDataBase : RoomDatabase() {
+    abstract fun pokemonDao(): PokemonDao
+}

--- a/app/src/main/java/com/rafael/mardom/app/data/db/DbConverters.kt
+++ b/app/src/main/java/com/rafael/mardom/app/data/db/DbConverters.kt
@@ -1,0 +1,21 @@
+package com.rafael.mardom.app.data.db
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.rafael.mardom.features.pokedex.data.local.db.PokemonStatsEntity
+
+class DbConverters {
+    @TypeConverter
+    fun listStatsToJson(value: List<PokemonStatsEntity>): String = Gson().toJson(value)
+
+    @TypeConverter
+    fun listStringToJson(value: List<String>): String = Gson().toJson(value)
+
+    @TypeConverter
+    fun jsonToStringList(value: String): List<String> =
+        Gson().fromJson(value, Array<String>::class.java).toList()
+
+    @TypeConverter
+    fun jsonToStatsList(value: String): List<PokemonStatsEntity> =
+        Gson().fromJson(value, Array<PokemonStatsEntity>::class.java).toList()
+}

--- a/app/src/main/java/com/rafael/mardom/app/di/LocalDataModule.kt
+++ b/app/src/main/java/com/rafael/mardom/app/di/LocalDataModule.kt
@@ -1,0 +1,27 @@
+package com.rafael.mardom.app.di
+
+import android.content.Context
+import androidx.room.Room
+import com.rafael.mardom.app.data.db.AppDataBase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LocalDataModule {
+
+    @Provides
+    @Singleton
+    fun provideDataBase(@ApplicationContext appContext: Context): AppDataBase {
+        return Room.databaseBuilder(
+            appContext,
+            AppDataBase::class.java, "PokedexDatabase"
+        )
+            .fallbackToDestructiveMigration()
+            .build()
+    }
+}

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/PokemonDataRepository.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/PokemonDataRepository.kt
@@ -3,20 +3,41 @@ package com.rafael.mardom.features.pokedex.data
 import com.rafael.mardom.app.domain.ErrorApp
 import com.rafael.mardom.app.domain.functional.Either
 import com.rafael.mardom.app.domain.functional.left
+import com.rafael.mardom.app.domain.functional.right
+import com.rafael.mardom.features.pokedex.data.local.PokemonLocalDataSource
 import com.rafael.mardom.features.pokedex.data.remote.PokemonRemoteDataSource
 import com.rafael.mardom.features.pokedex.domain.Pokemon
 import com.rafael.mardom.features.pokedex.domain.PokemonRepository
 import javax.inject.Inject
 
 class PokemonDataRepository @Inject constructor(
-    // private val localDataSource: PokemonLocalDataSource, // Será añadido en el futuro
+    private val localDataSource: PokemonLocalDataSource,
     private val remoteDataSource: PokemonRemoteDataSource
 ) : PokemonRepository {
     override suspend fun getAll(): Either<ErrorApp, List<Pokemon>> {
-        return try {
-            remoteDataSource.getAll()
-        }catch (e: java.lang.Exception){
+        val pokedexLocal = localDataSource.getAll()
+
+         try {
+            if (pokedexLocal.isLeft() || pokedexLocal.get().isEmpty()) {
+                remoteDataSource.getAll().fold(
+                    {
+                        return it.left()
+                    },
+                    {
+                        localDataSource.save(it)
+                        return it.right()
+                    }
+                )
+            } else {
+                return pokedexLocal.get().right()
+            }
+        } catch (e: java.lang.Exception) {
             return ErrorApp.DataError.left()
         }
     }
+
+    override suspend fun getById(id: Int): Either<ErrorApp, Pokemon?> = localDataSource.getById(id)
+
+    override suspend fun getByName(name: String): Either<ErrorApp, Pokemon?> = localDataSource.getByName(name)
+
 }

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/local/PokemonLocalDataSource.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/local/PokemonLocalDataSource.kt
@@ -1,0 +1,13 @@
+package com.rafael.mardom.features.pokedex.data.local
+
+import com.rafael.mardom.app.domain.ErrorApp
+import com.rafael.mardom.app.domain.functional.Either
+import com.rafael.mardom.features.pokedex.domain.Pokemon
+
+interface PokemonLocalDataSource {
+    fun getAll(): Either<ErrorApp, List<Pokemon>>
+    fun getById(id: Int): Either<ErrorApp, Pokemon?>
+    fun getByName(name: String): Either<ErrorApp, Pokemon?>
+    fun save(pokedex: List<Pokemon>): Either<ErrorApp, Boolean>
+    fun deleteAll()
+}

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/local/db/Entities.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/local/db/Entities.kt
@@ -1,0 +1,46 @@
+package com.rafael.mardom.features.pokedex.data.local.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+const val TABLE_POKEMON = "pokemon"
+const val PK_POKEMON = "pokemon_id"
+const val NAME_POKEMON = "pokemon_name"
+
+const val TABLE_STATS = "pokemon_stats"
+const val PK_STATS = "pokemon_stats_id"
+
+const val TABLE_SPRITE = "pokemon_sprite"
+const val PK_SPRITE = "pokemon_sprite_id"
+
+@Entity(tableName = TABLE_POKEMON)
+data class PokemonEntity(
+    @PrimaryKey
+    @ColumnInfo(name = PK_POKEMON) val id: Int,
+    @ColumnInfo(name = NAME_POKEMON) val name: String,
+    val description: String,
+    val height: Double,
+    val weight: Double,
+    val types: List<String>,
+    val stats: List<PokemonStatsEntity>,
+    @Embedded val sprites: PokemonSpriteEntity,
+)
+
+@Entity(tableName = TABLE_STATS)
+data class PokemonStatsEntity(
+    @PrimaryKey
+    @ColumnInfo(name = PK_STATS)
+    val name: String,
+    val base: Int
+)
+
+@Entity(tableName = TABLE_SPRITE)
+data class PokemonSpriteEntity(
+    @PrimaryKey
+    @ColumnInfo(name = PK_SPRITE) val front_default: String,
+    val front_shiny: String,
+    val back_default: String,
+    val back_shiny: String,
+)

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/local/db/LocalMapper.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/local/db/LocalMapper.kt
@@ -1,0 +1,55 @@
+package com.rafael.mardom.features.pokedex.data.local.db
+
+import com.rafael.mardom.features.pokedex.domain.Pokemon
+import com.rafael.mardom.features.pokedex.domain.PokemonSprite
+import com.rafael.mardom.features.pokedex.domain.PokemonStats
+
+fun PokemonEntity.toDomain() = Pokemon(
+    id = this.id,
+    name = this.name,
+    description = this.description,
+    height = this.height,
+    weight = this.weight,
+    types = this.types,
+    stats = this.stats.map {
+        it.toDomain()
+    },
+    sprites = this.sprites.toDomain()
+)
+
+fun PokemonStatsEntity.toDomain() = PokemonStats(
+    name = this.name,
+    base = this.base
+)
+
+fun PokemonSpriteEntity.toDomain() = PokemonSprite(
+    front_default = this.front_default,
+    front_shiny = this.front_shiny,
+    back_default = this.back_default,
+    back_shiny = this.back_shiny,
+)
+
+fun Pokemon.toEntity() = PokemonEntity(
+    id = this.id,
+    name = this.name,
+    description = this.description,
+    height = this.height,
+    weight = this.weight,
+    types = this.types,
+    stats = this.stats.map {
+        it.toEntity()
+    },
+    sprites = this.sprites.toEntity()
+)
+
+fun PokemonStats.toEntity() = PokemonStatsEntity(
+    name = this.name,
+    base = this.base
+)
+
+fun PokemonSprite.toEntity() = PokemonSpriteEntity(
+    front_default = this.front_default,
+    front_shiny = this.front_shiny,
+    back_default = this.back_default,
+    back_shiny = this.back_shiny,
+)

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/local/db/PokemonDao.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/local/db/PokemonDao.kt
@@ -1,0 +1,25 @@
+package com.rafael.mardom.features.pokedex.data.local.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface PokemonDao {
+
+    @Query("SELECT * FROM $TABLE_POKEMON")
+    fun findAll(): List<PokemonEntity>
+
+    @Query("SELECT * FROM $TABLE_POKEMON WHERE $PK_POKEMON = :id")
+    fun findById(id: Int): PokemonEntity?
+
+    @Query("SELECT * FROM $TABLE_POKEMON WHERE $NAME_POKEMON = :name")
+    fun findByName(name: String): PokemonEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun save(pokemonEntity: PokemonEntity)
+
+    @Query("DELETE FROM $TABLE_POKEMON")
+    fun deleteAll()
+}

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/data/local/db/PokemonDbLocalDataSource.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/data/local/db/PokemonDbLocalDataSource.kt
@@ -1,0 +1,69 @@
+package com.rafael.mardom.features.pokedex.data.local.db
+
+import com.rafael.mardom.app.domain.ErrorApp
+import com.rafael.mardom.app.domain.functional.Either
+import com.rafael.mardom.app.domain.functional.left
+import com.rafael.mardom.app.domain.functional.right
+import com.rafael.mardom.features.pokedex.data.local.PokemonLocalDataSource
+import com.rafael.mardom.features.pokedex.domain.Pokemon
+import javax.inject.Inject
+
+class PokemonDbLocalDataSource @Inject constructor(
+    private var dao: PokemonDao
+) : PokemonLocalDataSource {
+    override fun getAll(): Either<ErrorApp, List<Pokemon>> {
+        return try {
+
+            val pokedex = dao.findAll()
+
+            pokedex.map {
+                it.toDomain()
+            }.right()
+
+        } catch (e: java.lang.Exception) {
+            ErrorApp.DataError.left()
+        }
+    }
+
+    override fun getById(id: Int): Either<ErrorApp, Pokemon?> {
+        return try {
+
+            val pokemon = dao.findById(id)
+
+            pokemon?.toDomain().right()
+
+        } catch (e: java.lang.Exception) {
+            ErrorApp.DataError.left()
+        }
+    }
+
+    override fun getByName(name: String): Either<ErrorApp, Pokemon?> {
+        return try {
+
+            val pokemon = dao.findByName(name)
+
+            pokemon?.toDomain().right()
+
+        } catch (e: java.lang.Exception) {
+            ErrorApp.DataError.left()
+        }
+    }
+
+    override fun save(pokedex: List<Pokemon>): Either<ErrorApp, Boolean> {
+        return try {
+
+            pokedex.forEach {
+                dao.save(it.toEntity())
+            }
+
+            true.right()
+
+        } catch (e: java.lang.Exception) {
+            ErrorApp.DataError.left()
+        }
+    }
+
+    override fun deleteAll() {
+        dao.deleteAll()
+    }
+}

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/di/PokemonModule.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/di/PokemonModule.kt
@@ -1,6 +1,8 @@
 package com.rafael.mardom.features.pokedex.di
 
 import com.rafael.mardom.features.pokedex.data.PokemonDataRepository
+import com.rafael.mardom.features.pokedex.data.local.PokemonLocalDataSource
+import com.rafael.mardom.features.pokedex.data.local.db.PokemonDbLocalDataSource
 import com.rafael.mardom.features.pokedex.data.remote.PokemonRemoteDataSource
 import com.rafael.mardom.features.pokedex.data.remote.api.PokemonApiRemoteDataSource
 import com.rafael.mardom.features.pokedex.domain.PokemonRepository
@@ -19,4 +21,6 @@ abstract class PokemonModule {
     @Binds
     abstract fun bindPokemonRemoteApiDataSource(remoteSource: PokemonApiRemoteDataSource): PokemonRemoteDataSource
 
+    @Binds
+    abstract fun bindPokemonDbLocalDataSource(localSource: PokemonDbLocalDataSource): PokemonLocalDataSource
 }

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/di/PokemonProvidesModule.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/di/PokemonProvidesModule.kt
@@ -1,5 +1,7 @@
 package com.rafael.mardom.features.pokedex.di
 
+import com.rafael.mardom.app.data.db.AppDataBase
+import com.rafael.mardom.features.pokedex.data.local.db.PokemonDao
 import com.rafael.mardom.features.pokedex.data.remote.api.ApiEndPoints
 import dagger.Module
 import dagger.Provides
@@ -17,4 +19,9 @@ object PokemonProvidesModule {
     fun providesPokemonApiEndPoints(retrofit: Retrofit) : ApiEndPoints =
         retrofit.create(ApiEndPoints::class.java)
 
+    @Provides
+    @Singleton
+    fun providePokemonDao(appDatabase: AppDataBase): PokemonDao {
+        return appDatabase.pokemonDao()
+    }
 }

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/domain/Repositories.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/domain/Repositories.kt
@@ -5,4 +5,6 @@ import com.rafael.mardom.app.domain.functional.Either
 
 interface PokemonRepository {
     suspend fun getAll(): Either<ErrorApp, List<Pokemon>>
+    suspend fun getById(id: Int): Either<ErrorApp, Pokemon?>
+    suspend fun getByName(name: String): Either<ErrorApp, Pokemon?>
 }


### PR DESCRIPTION
## Descripción

Se desea guardar la información recogida de la API externa en la memoria local del dispositivo.
Para ello, se va a implementar RoomDatabase, con sus consecuentes tablas y un patrón Singleton de acceso a las mismas.

## ¿Cómo se ha implementado?

Se han creado las interfaces, clases y ficheros de la rama local de data.

Las entidades corresponden a los datos que se almacenan en las tablas de la base de datos. Como son tablas, disponen de una Primary Key, que cabe mencionar en el caso de los Sprites, se ha declarado el `front_default` como PK porque igualmente, se asume ninguna criatura repetirá sprite de ningún tipo.

Se ha establecido que la base de datos se destruya con cada actualización. Es una práctica un poco bruta en mi opinión, pero por el momento serán pocas las veces que se actualice y merezca la pena mantener los datos.

Se han creado Database Converters; a casos prácticos, funciones de extensión para parsear determinados tipos de datos a otros que puedan ser almacenables en las tablas. Por ejemplo:
- **ListString to Json 🔄️ Json to ListString**: Room no permite almacenar Listas de base, por lo que hace falta parsear la lista completa a un String formato Json que se almacene a pelo.
- **ListStats to Json 🔄️ Json to ListStats**: Siguiendo el mismo problema, no podemos guardar listas de nuestros propios objetos (aquí, `Stats`, a diferencia de `Sprites` que puede almacenarse con la etiqueta `@Embedded`), por lo que no queda más remedio que hacer el mismo código de parseo, igual que con Strings, pero esta vez con PokemonStats.
> Se intentó que esta función permitiera genéricos, pero no lo logré. Pendiente para el futuro si fuera posible.