### PR TITLE
Capa de Presentación: Segundo Avance

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,6 +90,9 @@ dependencies {
     // Pull to refresh
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 
+    // Charts
+    implementation 'com.diogobernardino:williamchart:3.10.1'
+
     // Base Kotlin dependencies
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/domain/GetPokemonByIdUseCase.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/domain/GetPokemonByIdUseCase.kt
@@ -1,0 +1,46 @@
+package com.rafael.mardom.features.pokedex.domain
+
+import com.rafael.mardom.app.domain.ErrorApp
+import com.rafael.mardom.app.domain.functional.Either
+import javax.inject.Inject
+
+class GetPokemonByIdUseCase @Inject constructor(
+    private val pokemonRepository: PokemonRepository
+) {
+    suspend operator fun invoke(pokemonId: Int): Either<ErrorApp, PokemonDetail?> =
+        pokemonRepository.getById(pokemonId).map {
+            it?.let { Pokemon ->
+                PokemonDetail(
+                    id = Pokemon.id,
+                    name = Pokemon.name,
+                    description = Pokemon.description,
+                    height = Pokemon.height,
+                    weight = Pokemon.weight,
+                    types = Pokemon.types,
+                    stats = Pokemon.stats.map { stat ->
+                        PokemonDetailStats(
+                            name = stat.name,
+                            base = stat.base
+                        )
+                    },
+                    sprites = Pokemon.sprites
+                )
+            }
+        }
+
+    data class PokemonDetail(
+        val id: Int,
+        val name: String,
+        val description: String,
+        val height: Double,
+        val weight: Double,
+        val types: List<String>,
+        val stats: List<PokemonDetailStats>,
+        val sprites: PokemonSprite,
+    )
+
+    data class PokemonDetailStats(
+        val name: String,
+        val base: Int
+    )
+}

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokemonDetailFragment.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokemonDetailFragment.kt
@@ -69,6 +69,8 @@ class PokemonDetailFragment : Fragment() {
             pokemonHeight.text = model.height.toString()
             pokemonWeight.text = model.weight.toString()
             pokemonSprite.loadUrl(model.sprites.front_default)
+            pokemonType1.text = model.types[0]
+            pokemonType2.text = if (model.types.size > 1) model.types[1] else ""
 
             toolbar.apply {
                 title = "# ${model.id}  - ${model.name.uppercase()}"

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokemonDetailFragment.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokemonDetailFragment.kt
@@ -1,32 +1,101 @@
 package com.rafael.mardom.features.pokedex.presentation
 
-import androidx.lifecycle.ViewModelProvider
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.rafael.mardom.R
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.rafael.mardom.app.extensions.loadUrl
+import com.rafael.mardom.databinding.FragmentPokemonDetailBinding
+import com.rafael.mardom.features.pokedex.domain.GetPokemonByIdUseCase.*
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class PokemonDetailFragment : Fragment() {
-
-    companion object {
-        fun newInstance() = PokemonDetailFragment()
-    }
-
-    private lateinit var viewModel: PokemonDetailViewModel
+    private var binding: FragmentPokemonDetailBinding? = null
+    private val viewModel by viewModels<PokemonDetailViewModel>()
+    private val args: PokemonDetailFragmentArgs by navArgs()
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_pokemon_detail, container, false)
+        binding = FragmentPokemonDetailBinding.inflate(inflater)
+        setupView()
+        return binding?.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProvider(this).get(PokemonDetailViewModel::class.java)
-        // TODO: Use the ViewModel
+    private fun setupView() {
+        binding?.apply {
+            toolbar.apply {
+                setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        }
     }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+        viewModel.loadAnimal(args.pokemonId)
+    }
+
+    private fun setupObservers() {
+        val state = Observer<PokemonDetailViewModel.UiState> {
+            if (it.error != null) {
+                // TODO
+            } else {
+                if (it.isLoading) {
+                    // TODO
+                } else {
+                    it.pokemon?.let { model ->
+                        bind(model)
+                    }
+                }
+            }
+        }
+        viewModel.uiState.observe(viewLifecycleOwner, state)
+    }
+
+    private fun bind(model: PokemonDetail) {
+        binding?.apply {
+            pokemonDescription.text = model.description
+            pokemonHeight.text = model.height.toString()
+            pokemonWeight.text = model.weight.toString()
+            pokemonSprite.loadUrl(model.sprites.front_default)
+
+            toolbar.apply {
+                title = "# ${model.id}  - ${model.name.uppercase()}"
+                toolbarSprite.loadUrl(model.sprites.front_default)
+            }
+
+            buildStatsChart(model.stats)
+        }
+    }
+
+    private fun buildStatsChart(stats: List<PokemonDetailStats>) {
+        val animationDuration = 1000L
+
+        val chartSet = mutableListOf<Pair<String, Float>>()
+
+        stats.forEach{
+            chartSet.add(
+                "${it.base} - ${it.name.uppercase()}" to ((it.base).toFloat()))
+        }
+
+        chartSet.reverse()
+
+        binding?.apply {
+            statsChart.animation.duration = animationDuration
+            statsChart.animate(chartSet)
+        }
+    }
+
 
 }

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokemonDetailViewModel.kt
@@ -1,7 +1,46 @@
 package com.rafael.mardom.features.pokedex.presentation
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rafael.mardom.app.domain.ErrorApp
+import com.rafael.mardom.features.pokedex.domain.GetPokemonByIdUseCase
+import com.rafael.mardom.features.pokedex.domain.GetPokemonByIdUseCase.*
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class PokemonDetailViewModel : ViewModel() {
-    // TODO: Implement the ViewModel
+@HiltViewModel
+class PokemonDetailViewModel @Inject constructor(
+    private val getPokemonByIdUseCase: GetPokemonByIdUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState>
+        get() = _uiState
+
+    var currentUiState = UiState()
+
+    fun loadAnimal(id: Int) {
+        currentUiState = currentUiState.copy(isLoading = true)
+        _uiState.value = currentUiState
+        viewModelScope.launch(Dispatchers.IO) {
+            getPokemonByIdUseCase.invoke(id).fold({
+                currentUiState = currentUiState.copy(error = it)
+                _uiState.postValue(currentUiState)
+            }, {
+                currentUiState = currentUiState.copy(isLoading = false, pokemon = it, error = null)
+                _uiState.postValue(currentUiState)
+            })
+
+        }
+    }
+
+    data class UiState(
+        val error: ErrorApp? = null,
+        val isLoading: Boolean = false,
+        val pokemon: PokemonDetail? = null
+    )
 }

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M480,800 L160,480l320,-320 42,42 -248,248h526v60L274,510l248,248 -42,42Z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_pokemon_detail.xml
+++ b/app/src/main/res/layout/fragment_pokemon_detail.xml
@@ -1,13 +1,114 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".features.pokedex.presentation.PokemonDetailFragment">
 
-    <TextView
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="POKEMONCHO" />
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/ic_arrow_back"
+        app:title="aaa"
+        app:titleCentered="true">
 
-</FrameLayout>
+        <ImageView
+            android:id="@+id/toolbar_sprite"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="end"
+            android:layout_marginEnd="12dp"
+            tools:src="@tools:sample/avatars" />
+
+    </com.google.android.material.appbar.MaterialToolbar>
+
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/data"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        app:layout_constraintStart_toStartOf="@id/toolbar"
+        app:layout_constraintTop_toBottomOf="@id/toolbar">
+
+        <!-- Pokemon Sprites -->
+        <ImageView
+            android:id="@+id/pokemon_sprite"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@tools:sample/avatars" />
+
+        <!-- Pokemon Types -->
+        <TextView
+            android:id="@+id/pokemon_type1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toStartOf="@id/pokemon_type2"
+            app:layout_constraintStart_toEndOf="@id/pokemon_sprite"
+            app:layout_constraintTop_toTopOf="@id/pokemon_sprite"
+            tools:text="aaaa" />
+
+        <TextView
+            android:id="@+id/pokemon_type2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/pokemon_type1"
+            app:layout_constraintTop_toTopOf="@id/pokemon_type1"
+            tools:text="aaaa" />
+
+        <!-- Pokemon Description -->
+        <TextView
+            android:id="@+id/pokemon_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="12dp"
+            android:textAlignment="center"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/pokemon_sprite"
+            app:layout_constraintTop_toBottomOf="@id/pokemon_type1"
+            tools:text="aaaa" />
+
+        <!-- Pokemon Height -->
+        <TextView
+            android:id="@+id/pokemon_height"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toStartOf="@id/pokemon_weight"
+            app:layout_constraintStart_toEndOf="@id/pokemon_sprite"
+            app:layout_constraintTop_toBottomOf="@id/pokemon_description"
+            tools:text="aaaa" />
+
+        <!-- Pokemon Weight -->
+        <TextView
+            android:id="@+id/pokemon_weight"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/pokemon_height"
+            app:layout_constraintTop_toTopOf="@id/pokemon_height"
+            tools:text="aaaa" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- Pokemon Stats -->
+    <com.db.williamchart.view.HorizontalBarChartView
+        android:id="@+id/stats_chart"
+        android:layout_width="0dp"
+        android:layout_height="150dp"
+        android:background="@color/teal_200"
+        android:padding="24dp"
+        android:layout_margin="24dp"
+        app:chart_axis="y"
+        app:chart_barsBackgroundColor="@color/white"
+        app:chart_barsColor="@color/black"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/data" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -21,11 +21,11 @@
         android:name="com.rafael.mardom.features.pokedex.presentation.PokemonDetailFragment"
         tools:layout="@layout/fragment_pokemon_detail">
 
-    <argument
-        android:name="pokemonId"
-        android:defaultValue="0"
-        app:argType="integer"
-        app:nullable="false" />
+        <argument
+            android:name="pokemonId"
+            android:defaultValue="0"
+            app:argType="integer"
+            app:nullable="false" />
 
     </fragment>
 


### PR DESCRIPTION
## Descripción

Se requiere de una pantalla que permita visualizar un detalle de la criatura seleccionada en el detalle de la Pokedex.
Se visualizarán los datos recibidos por la data class del caso de uso correspondiente.

## ¿Cómo se ha implementado?

Una cantidad considerable de la capa de presentación fue desarrollado en el primer avance. Para más documentación al respecto, ver [Capa de Presentación: Primer Avance](https://github.com/RafaX8/android-pokedex/pull/12)

En este avance se han realizado cambios poco significativos a nivel de código, pero se ha realizado una primera versión del detalle de cada criatura y se ha creado el caso de uso para recibir datos del mismo.

- `GetPokemonByIdUseCase`: Este caso de uso transforma las data classes de dominio a una data class que será visible en la capa de presentación. Se han creado, de hecho, 2 data classes, ya que stats es un atributo compuesto por otro modelo de dominio, que también se utilizará y por lo tanto se ha mapeado.

 De igual manera, se ha introducido una librería para la implementación de gráficos, que permitirá mostrar las estadísticas de forma visual y no meramente informativa.

A continuación, las vistas que se han trabajado. **NO** son versiones definitivas, simplemente sirven para observar el funcionamiento de la app.
- `fragment_pokemon_detail`: Fragmento con información de las criaturas.

Adicionalmente, se ha añadido un icono de flecha para la navegación del detalle devuelta al listado.

## Recursos

- Librería de terceros con licencia Free-to-Use para la elaboración de gráficas de datos: https://github.com/diogobernardino/williamchart 
- Iconos: [Google Fonts and Material Symbols](https://fonts.google.com/icons)

## Screenshots or Video

https://user-images.githubusercontent.com/104196849/230437738-ec831b54-f82c-404c-9c71-a39c7c04a835.mp4

