### PR TITLE
Added Skeleton Layout on loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,6 +93,9 @@ dependencies {
     // Charts
     implementation 'com.diogobernardino:williamchart:3.10.1'
 
+    // Skeleton
+    implementation 'com.faltenreich:skeletonlayout:4.0.0'
+
     // Base Kotlin dependencies
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokedexListFragment.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokedexListFragment.kt
@@ -9,6 +9,9 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.faltenreich.skeletonlayout.Skeleton
+import com.faltenreich.skeletonlayout.applySkeleton
+import com.rafael.mardom.R
 import com.rafael.mardom.app.presentation.error.AppErrorHandler
 import com.rafael.mardom.databinding.FragmentPokedexListBinding
 import com.rafael.mardom.features.pokedex.presentation.adapter.PokedexListAdapter
@@ -17,7 +20,7 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class PokedexListFragment : Fragment() {
-
+    private var skeleton: Skeleton? = null
     private var binding: FragmentPokedexListBinding? = null
     private val pokedexListAdapter = PokedexListAdapter()
     private val viewModel by viewModels<PokedexListViewModel>()
@@ -45,6 +48,7 @@ class PokedexListFragment : Fragment() {
                     LinearLayoutManager.VERTICAL,
                     false
                 )
+                skeleton = applySkeleton(R.layout.view_item_pokedex_pokemon, 9)
             }
             pokedexListAdapter.setOnClickItem { pokemonId ->
                 navigateToDetail(pokemonId)
@@ -60,11 +64,13 @@ class PokedexListFragment : Fragment() {
     private fun setUpObservers() {
         val state = Observer<PokedexListViewModel.UiState> {
             if (it.error != null) {
+                skeleton?.showOriginal()
                 appErrorHandler.navigateToError(it.error)
             } else {
                 if (it.isLoading) {
-                    //TODO
+                    skeleton?.showSkeleton()
                 } else {
+                    skeleton?.showOriginal()
                     pokedexListAdapter.submitList(it.pokedex)
                 }
             }

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokedexListViewModel.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokedexListViewModel.kt
@@ -59,7 +59,7 @@ class PokedexListViewModel @Inject constructor(
 
     data class UiState(
         val error: ErrorApp? = null,
-        val isLoading: Boolean = false,
+        val isLoading: Boolean = true,
         val pokedex: List<ItemUiState>? = null,
     )
 

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokemonDetailFragment.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokemonDetailFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.faltenreich.skeletonlayout.Skeleton
 import com.rafael.mardom.R
 import com.rafael.mardom.app.extensions.loadUrl
 import com.rafael.mardom.app.presentation.error.AppErrorHandler
@@ -19,6 +20,7 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class PokemonDetailFragment : Fragment() {
+    private var skeleton: Skeleton? = null
     private var binding: FragmentPokemonDetailBinding? = null
     private val viewModel by viewModels<PokemonDetailViewModel>()
     private val args: PokemonDetailFragmentArgs by navArgs()
@@ -43,6 +45,7 @@ class PokemonDetailFragment : Fragment() {
                     findNavController().navigateUp()
                 }
             }
+            skeleton = skeletonDetail
         }
     }
 
@@ -55,11 +58,13 @@ class PokemonDetailFragment : Fragment() {
     private fun setupObservers() {
         val state = Observer<PokemonDetailViewModel.UiState> {
             if (it.error != null) {
+                skeleton?.showOriginal()
                 appErrorHandler.navigateToError(it.error)
             } else {
                 if (it.isLoading) {
-                    // TODO
+                    skeleton?.showSkeleton()
                 } else {
+                    skeleton?.showOriginal()
                     it.pokemon?.let { model ->
                         bind(model)
                     }

--- a/app/src/main/res/layout/fragment_pokemon_detail.xml
+++ b/app/src/main/res/layout/fragment_pokemon_detail.xml
@@ -31,191 +31,197 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/toolbar">
 
-        <!-- Data -->
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/data"
+        <com.faltenreich.skeletonlayout.SkeletonLayout
+            android:id="@+id/skeleton_detail"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="@dimen/spacing_medium"
-            app:layout_constraintStart_toStartOf="@id/toolbar"
-            app:layout_constraintTop_toBottomOf="@id/toolbar">
+            android:layout_height="match_parent">
 
-            <!-- Pokemon Sprites -->
-            <ImageView
-                android:id="@+id/pokeball_shape"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:background="@drawable/pokedex_item_poke_shape"
-                app:layout_constraintBottom_toBottomOf="@id/pokemon_sprite"
-                app:layout_constraintEnd_toEndOf="@id/pokemon_sprite"
-                app:layout_constraintStart_toStartOf="@id/pokemon_sprite"
-                app:layout_constraintTop_toTopOf="@id/pokemon_sprite" />
-
-            <ImageView
-                android:id="@+id/pokemon_sprite"
-                android:layout_width="@dimen/detail_default_sprite_size"
-                android:layout_height="@dimen/detail_default_sprite_size"
-                app:layout_constraintEnd_toStartOf="@id/alt_sprites"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:src="@tools:sample/avatars" />
-
-            <!-- Alternative Sprites -->
+            <!-- Data -->
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/alt_sprites"
-                android:layout_width="@dimen/detail_alter_sprite_size"
-                android:layout_height="0dp"
-                android:background="@drawable/rounded_corners_shape"
-                android:backgroundTint="@color/md_theme_light_secondary"
-                app:layout_constraintBottom_toBottomOf="@id/pokemon_sprite"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/pokemon_sprite"
-                app:layout_constraintTop_toTopOf="@id/pokemon_sprite">
+                android:id="@+id/data"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/spacing_medium"
+                app:layout_constraintStart_toStartOf="@id/toolbar"
+                app:layout_constraintTop_toBottomOf="@id/toolbar">
 
+                <!-- Pokemon Sprites -->
                 <ImageView
-                    android:id="@+id/front_shiny"
+                    android:id="@+id/pokeball_shape"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
-                    app:layout_constraintBottom_toTopOf="@id/back_default"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    android:background="@drawable/pokedex_item_poke_shape"
+                    app:layout_constraintBottom_toBottomOf="@id/pokemon_sprite"
+                    app:layout_constraintEnd_toEndOf="@id/pokemon_sprite"
+                    app:layout_constraintStart_toStartOf="@id/pokemon_sprite"
+                    app:layout_constraintTop_toTopOf="@id/pokemon_sprite" />
+
+                <ImageView
+                    android:id="@+id/pokemon_sprite"
+                    android:layout_width="@dimen/detail_default_sprite_size"
+                    android:layout_height="@dimen/detail_default_sprite_size"
+                    app:layout_constraintEnd_toStartOf="@id/alt_sprites"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
                     tools:src="@tools:sample/avatars" />
 
-                <ImageView
-                    android:id="@+id/back_default"
-                    android:layout_width="0dp"
+                <!-- Alternative Sprites -->
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/alt_sprites"
+                    android:layout_width="@dimen/detail_alter_sprite_size"
                     android:layout_height="0dp"
-                    app:layout_constraintBottom_toTopOf="@id/back_shiny"
+                    android:background="@drawable/rounded_corners_shape"
+                    android:backgroundTint="@color/md_theme_light_secondary"
+                    app:layout_constraintBottom_toBottomOf="@id/pokemon_sprite"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="@id/front_shiny"
-                    app:layout_constraintTop_toBottomOf="@id/front_shiny"
-                    tools:src="@tools:sample/avatars" />
+                    app:layout_constraintStart_toEndOf="@id/pokemon_sprite"
+                    app:layout_constraintTop_toTopOf="@id/pokemon_sprite">
 
-                <ImageView
-                    android:id="@+id/back_shiny"
+                    <ImageView
+                        android:id="@+id/front_shiny"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        app:layout_constraintBottom_toTopOf="@id/back_default"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:src="@tools:sample/avatars" />
+
+                    <ImageView
+                        android:id="@+id/back_default"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        app:layout_constraintBottom_toTopOf="@id/back_shiny"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="@id/front_shiny"
+                        app:layout_constraintTop_toBottomOf="@id/front_shiny"
+                        tools:src="@tools:sample/avatars" />
+
+                    <ImageView
+                        android:id="@+id/back_shiny"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="@id/front_shiny"
+                        app:layout_constraintTop_toBottomOf="@id/back_default"
+                        tools:src="@tools:sample/avatars" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <!-- Pokemon Description -->
+                <TextView
+                    android:id="@+id/pokemon_description_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/description_label"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toTopOf="@id/pokemon_description"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/pokemon_sprite" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/pokemon_description"
                     android:layout_width="0dp"
-                    android:layout_height="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/spacing_medium"
+                    android:background="@drawable/rounded_corners_shape"
+                    android:backgroundTint="@color/md_theme_light_secondaryContainer"
+                    android:padding="@dimen/spacing_small"
+                    android:textAlignment="center"
+                    android:textColor="@color/md_theme_light_onSecondaryContainer"
+                    android:textSize="@dimen/font_medium"
+                    android:textStyle="italic"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/pokemon_description_label"
+                    app:layout_constraintTop_toBottomOf="@id/pokemon_description_label"
+                    tools:text="@string/lorem_ipsum" />
+
+                <!-- Height and Weight data -->
+                <LinearLayout
+                    android:id="@+id/extra"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/spacing_small"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/pokemon_description">
+
+                    <!-- Pokemon Height -->
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_height" />
+
+                    <TextView
+                        android:id="@+id/pokemon_height"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        tools:text="HEIGHT" />
+
+                    <!-- Pokemon Weight -->
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_weight" />
+
+                    <TextView
+                        android:id="@+id/pokemon_weight"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        tools:text="WEIGHT" />
+                </LinearLayout>
+
+                <!-- Pokemon Types -->
+                <TextView
+                    android:id="@+id/pokemon_type1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/spacing_medium"
+                    android:background="@drawable/type_brick_shape"
+                    android:textAlignment="center"
+                    android:textAllCaps="true"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/font_small"
+                    app:layout_constraintBottom_toTopOf="@id/stats_chart"
+                    app:layout_constraintEnd_toStartOf="@id/pokemon_type2"
+                    app:layout_constraintStart_toStartOf="@id/stats_chart"
+                    app:layout_constraintTop_toBottomOf="@id/extra"
+                    tools:backgroundTint="@color/md_theme_light_primary"
+                    tools:text="TYPE 1" />
+
+                <TextView
+                    android:id="@+id/pokemon_type2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/type_brick_shape"
+                    android:textAlignment="center"
+                    android:textAllCaps="true"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/font_small"
+                    app:layout_constraintEnd_toEndOf="@id/stats_chart"
+                    app:layout_constraintStart_toEndOf="@id/pokemon_type1"
+                    app:layout_constraintTop_toTopOf="@id/pokemon_type1"
+                    tools:backgroundTint="@color/md_theme_dark_primary"
+                    tools:text="TYPE 2" />
+
+                <!-- Pokemon Stats -->
+                <com.db.williamchart.view.HorizontalBarChartView
+                    android:id="@+id/stats_chart"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/chart_height"
+                    android:background="@drawable/rounded_corners_shape"
+                    android:backgroundTint="@color/md_theme_light_secondary"
+                    android:padding="@dimen/spacing_large"
+                    app:chart_axis="y"
+                    app:chart_barsColor="@color/md_theme_dark_tertiary"
+                    app:chart_labelsColor="@color/md_theme_light_onSecondary"
+                    app:chart_labelsSize="@dimen/font_small"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="@id/front_shiny"
-                    app:layout_constraintTop_toBottomOf="@id/back_default"
-                    tools:src="@tools:sample/avatars" />
-
+                    app:layout_constraintStart_toStartOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <!-- Pokemon Description -->
-            <TextView
-                android:id="@+id/pokemon_description_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/description_label"
-                android:textStyle="bold"
-                app:layout_constraintBottom_toTopOf="@id/pokemon_description"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/pokemon_sprite" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/pokemon_description"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="@dimen/spacing_medium"
-                android:background="@drawable/rounded_corners_shape"
-                android:backgroundTint="@color/md_theme_light_secondaryContainer"
-                android:padding="@dimen/spacing_small"
-                android:textAlignment="center"
-                android:textColor="@color/md_theme_light_onSecondaryContainer"
-                android:textSize="@dimen/font_medium"
-                android:textStyle="italic"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@id/pokemon_description_label"
-                app:layout_constraintTop_toBottomOf="@id/pokemon_description_label"
-                tools:text="@string/lorem_ipsum" />
-
-            <!-- Height and Weight data -->
-            <LinearLayout
-                android:id="@+id/extra"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="@dimen/spacing_small"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/pokemon_description">
-
-                <!-- Pokemon Height -->
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_height" />
-
-                <TextView
-                    android:id="@+id/pokemon_height"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    tools:text="HEIGHT" />
-
-                <!-- Pokemon Weight -->
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_weight" />
-
-                <TextView
-                    android:id="@+id/pokemon_weight"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    tools:text="WEIGHT" />
-            </LinearLayout>
-
-            <!-- Pokemon Types -->
-            <TextView
-                android:id="@+id/pokemon_type1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="@dimen/spacing_medium"
-                android:background="@drawable/type_brick_shape"
-                android:textAlignment="center"
-                android:textAllCaps="true"
-                android:textColor="@color/white"
-                android:textSize="@dimen/font_small"
-                app:layout_constraintBottom_toTopOf="@id/stats_chart"
-                app:layout_constraintEnd_toStartOf="@id/pokemon_type2"
-                app:layout_constraintStart_toStartOf="@id/stats_chart"
-                app:layout_constraintTop_toBottomOf="@id/extra"
-                tools:backgroundTint="@color/md_theme_light_primary"
-                tools:text="TYPE 1" />
-
-            <TextView
-                android:id="@+id/pokemon_type2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@drawable/type_brick_shape"
-                android:textAlignment="center"
-                android:textAllCaps="true"
-                android:textColor="@color/white"
-                android:textSize="@dimen/font_small"
-                app:layout_constraintEnd_toEndOf="@id/stats_chart"
-                app:layout_constraintStart_toEndOf="@id/pokemon_type1"
-                app:layout_constraintTop_toTopOf="@id/pokemon_type1"
-                tools:backgroundTint="@color/md_theme_dark_primary"
-                tools:text="TYPE 2" />
-
-            <!-- Pokemon Stats -->
-            <com.db.williamchart.view.HorizontalBarChartView
-                android:id="@+id/stats_chart"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/chart_height"
-                android:background="@drawable/rounded_corners_shape"
-                android:backgroundTint="@color/md_theme_light_secondary"
-                android:padding="@dimen/spacing_large"
-                app:chart_axis="y"
-                app:chart_barsColor="@color/md_theme_dark_tertiary"
-                app:chart_labelsColor="@color/md_theme_light_onSecondary"
-                app:chart_labelsSize="@dimen/font_small"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.faltenreich.skeletonlayout.SkeletonLayout>
     </androidx.core.widget.NestedScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Descripción
Añadir una pantalla de carga cuando la aplicación aún esté recopilando datos.

## ¿Cómo se ha implementado?
Se ha optado por un skeleton layout, que en esencia mimetiza el layout que está aún cargando datos, poniendo bloques por encima que simulen ser los datos del layout cargado. Se podría haber hecho manualmente, pero en su lugar se ha implementado la siguiente librería gratuita: [Faltenreich SkeletonLayout](https://github.com/Faltenreich/SkeletonLayout)