### PR TITLE
added Navigation through Detail Fragments.

### DIFF
--- a/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokedexListFragment.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokedexListFragment.kt
@@ -79,7 +79,7 @@ class PokedexListFragment : Fragment() {
 
     private fun navigateToDetail(pokemonId: Int) {
         findNavController().navigate(
-            PokedexListFragmentDirections.actionToAdoptionsDetail(pokemonId)
+            PokedexListFragmentDirections.actionToPokemonDetail(pokemonId)
         )
     }
 }

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokemonDetailFragment.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokemonDetailFragment.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.faltenreich.skeletonlayout.Skeleton
-import com.rafael.mardom.R
 import com.rafael.mardom.app.extensions.ColorTypePairing
 import com.rafael.mardom.app.extensions.loadUrl
 import com.rafael.mardom.app.presentation.error.AppErrorHandler
@@ -43,7 +42,7 @@ class PokemonDetailFragment : Fragment() {
         binding?.apply {
             toolbar.apply {
                 setNavigationOnClickListener {
-                    findNavController().navigateUp()
+                    navigateToPokedex()
                 }
             }
             skeleton = skeletonDetail
@@ -112,6 +111,13 @@ class PokemonDetailFragment : Fragment() {
             }
 
             buildStatsChart(model.stats)
+
+            beforeAction.setOnClickListener {
+                navigateBefore(model.id)
+            }
+            nextAction.setOnClickListener {
+                navigateNext(model.id)
+            }
         }
     }
 
@@ -138,5 +144,25 @@ class PokemonDetailFragment : Fragment() {
             statsChart.animation.duration = animationDuration
             statsChart.animate(chartSet)
         }
+    }
+
+    private fun navigateToPokedex() {
+        findNavController().navigate(
+            PokemonDetailFragmentDirections.actionToPokedex()
+        )
+    }
+
+    private fun navigateBefore(pokemonId: Int) {
+        if (pokemonId > 1)
+            findNavController().navigate(
+                PokemonDetailFragmentDirections.actionToPokemonDetail(pokemonId - 1)
+            )
+    }
+
+    private fun navigateNext(pokemonId: Int) {
+        if (pokemonId < 151)
+            findNavController().navigate(
+                PokemonDetailFragmentDirections.actionToPokemonDetail(pokemonId + 1)
+            )
     }
 }

--- a/app/src/main/res/drawable/ic_navigate_before.xml
+++ b/app/src/main/res/drawable/ic_navigate_before.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M561,720 L320,479l241,-241 43,43 -198,198 198,198 -43,43Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_navigate_next.xml
+++ b/app/src/main/res/drawable/ic_navigate_next.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m375,720 l-43,-43 198,-198 -198,-198 43,-43 241,241 -241,241Z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_pokemon_detail.xml
+++ b/app/src/main/res/layout/fragment_pokemon_detail.xml
@@ -218,9 +218,30 @@
                     app:chart_barsColor="@color/md_theme_dark_tertiary"
                     app:chart_labelsColor="@color/md_theme_light_onSecondary"
                     app:chart_labelsSize="@dimen/font_small"
-                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintBottom_toTopOf="@id/before_action"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />
+
+                <ImageButton
+                    android:id="@+id/before_action"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:backgroundTint="@color/md_theme_light_background"
+                    android:src="@drawable/ic_navigate_before"
+                    app:layout_constraintStart_toStartOf="@id/stats_chart"
+                    app:layout_constraintTop_toBottomOf="@id/stats_chart"
+                    app:tint="@color/md_theme_light_primary" />
+
+                <ImageButton
+                    android:id="@+id/next_action"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:backgroundTint="@color/md_theme_light_background"
+                    android:src="@drawable/ic_navigate_next"
+                    app:layout_constraintEnd_toEndOf="@id/stats_chart"
+                    app:layout_constraintTop_toBottomOf="@id/stats_chart"
+                    app:tint="@color/md_theme_light_primary" />
+
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.faltenreich.skeletonlayout.SkeletonLayout>
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -11,7 +11,7 @@
         tools:layout="@layout/fragment_pokedex_list">
 
         <action
-            android:id="@+id/action_to_adoptions_detail"
+            android:id="@+id/action_to_pokemon_detail"
             app:destination="@id/pokemon_detail_fragment" />
 
     </fragment>
@@ -27,6 +27,13 @@
             app:argType="integer"
             app:nullable="false" />
 
+        <action
+            android:id="@+id/action_to_pokedex"
+            app:destination="@id/pokedex_fragment" />
+
+        <action
+            android:id="@+id/action_to_pokemon_detail"
+            app:destination="@id/pokemon_detail_fragment" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
## Descripción
Para no salir y entrar del detalle cada dos por tres, se va a permitir la navegación a la criatura siguiente o anterior en la lista.

## ¿Cómo se ha implementado?
Ha sido una adición muy simple, donde nada más se han añadido las navegaciones necesarias al fichero `nav_graph.xml` y se han implementado unos botones en el detalle que, al clicar, llama a la misma navegación que había de la lista al detalle, pero sumando o restando en 1 el ID del Pokemon.

A modo un poco de parche y para evitar un comportamiento indeseado, se ha añadido una comprobación para que la navegación se mantenga en el rango de 1-151, ya que por debajo no existen criaturas y por encima no se han descargado más datos.

Es posible mejorar el código y comportamiento, pero por falta de tiempo, NO SE VA A TRABAJAR.