### PR TITLE
Added Swipe to refresh in pokedex List and Error Fragment

### DIFF
--- a/app/src/main/java/com/rafael/mardom/app/presentation/error/AppErrorHandler.kt
+++ b/app/src/main/java/com/rafael/mardom/app/presentation/error/AppErrorHandler.kt
@@ -20,10 +20,10 @@ class AppErrorHandler @Inject constructor(@ActivityContext private val context: 
                     .navigate(NavGraphDirections.actionToDataError())
             is ErrorApp.NoInternetError ->
                 Navigation.findNavController(activity, navFragment)
-                    .navigate(NavGraphDirections.actionToDataError())
+                    .navigate(NavGraphDirections.actionToNointernetError())
             is ErrorApp.TimeOutError ->
                 Navigation.findNavController(activity, navFragment)
-                    .navigate(NavGraphDirections.actionToDataError())
+                    .navigate(NavGraphDirections.actionToServerError())
             else ->
                 Navigation.findNavController(activity, navFragment)
                     .navigate(NavGraphDirections.actionToUnknownError())

--- a/app/src/main/java/com/rafael/mardom/app/presentation/error/ErrorFragment.kt
+++ b/app/src/main/java/com/rafael/mardom/app/presentation/error/ErrorFragment.kt
@@ -5,8 +5,15 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.Navigation
+import androidx.navigation.fragment.findNavController
+import com.rafael.mardom.NavGraphDirections
 import com.rafael.mardom.databinding.FragmentErrorBinding
+import com.rafael.mardom.features.pokedex.presentation.PokemonDetailFragmentDirections
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -18,7 +25,20 @@ open class ErrorFragment @Inject constructor() : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View? {
         binding = FragmentErrorBinding.inflate(inflater)
+        setupView()
         return binding?.root
+    }
+
+    protected fun setupView(){
+        binding?.apply {
+            swipeRefreshLayout.apply {
+                setOnRefreshListener {
+                    findNavController().navigate(
+                        ErrorFragmentDirections.actionToPokedex()
+                    )
+                }
+            }
+        }
     }
 
     protected fun setErrorTitle(title: String) {

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokedexListFragment.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokedexListFragment.kt
@@ -53,6 +53,11 @@ class PokedexListFragment : Fragment() {
             pokedexListAdapter.setOnClickItem { pokemonId ->
                 navigateToDetail(pokemonId)
             }
+            swipeRefreshLayout.apply {
+                setOnRefreshListener {
+                    viewModel.refresh()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokedexListViewModel.kt
+++ b/app/src/main/java/com/rafael/mardom/features/pokedex/presentation/PokedexListViewModel.kt
@@ -40,7 +40,7 @@ class PokedexListViewModel @Inject constructor(
     }
 
     private fun errorState(errorApp: ErrorApp) {
-        currentUiState = currentUiState.copy(error = errorApp)
+        currentUiState = currentUiState.copy(error = errorApp, isLoading = false)
         _uiState.postValue(currentUiState)
     }
 
@@ -57,9 +57,15 @@ class PokedexListViewModel @Inject constructor(
         _uiState.postValue(currentUiState)
     }
 
+    fun refresh() {
+        viewModelScope.launch(Dispatchers.IO) {
+            loadPokedex()
+        }
+    }
+
     data class UiState(
         val error: ErrorApp? = null,
-        val isLoading: Boolean = true,
+        val isLoading: Boolean = false,
         val pokedex: List<ItemUiState>? = null,
     )
 

--- a/app/src/main/res/layout/fragment_error.xml
+++ b/app/src/main/res/layout/fragment_error.xml
@@ -7,48 +7,56 @@
     android:gravity="center"
     tools:context=".app.presentation.error.ErrorFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <ImageView
-            android:id="@+id/error_icon"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="@dimen/error_icon_height"
-            android:background="@drawable/rounded_corners_shape"
-            android:src="@drawable/ic_error"
-            app:layout_constraintBottom_toTopOf="@id/label_title_error"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tint="@color/md_theme_light_error" />
+            android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/label_title_error"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:textColor="@color/black"
-            android:textSize="@dimen/font_large"
-            app:layout_constraintBottom_toTopOf="@id/label_desc_error"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/error_icon"
-            tools:text="ERROR TITLE" />
+            <ImageView
+                android:id="@+id/error_icon"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/error_icon_height"
+                android:background="@drawable/rounded_corners_shape"
+                android:src="@drawable/ic_error"
+                app:layout_constraintBottom_toTopOf="@id/label_title_error"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/md_theme_light_error" />
 
-        <TextView
-            android:id="@+id/label_desc_error"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom"
-            android:layout_margin="@dimen/spacing_large"
-            android:background="@drawable/rounded_corners_shape"
-            android:backgroundTint="@color/md_theme_light_errorContainer"
-            android:gravity="center"
-            android:textColor="@color/md_theme_light_onErrorContainer"
-            android:textSize="@dimen/font_medium"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label_title_error"
-            tools:text="@string/lorem_ipsum" />
+            <TextView
+                android:id="@+id/label_title_error"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/font_large"
+                app:layout_constraintBottom_toTopOf="@id/label_desc_error"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/error_icon"
+                tools:text="ERROR TITLE" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/label_desc_error"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:layout_margin="@dimen/spacing_large"
+                android:background="@drawable/rounded_corners_shape"
+                android:backgroundTint="@color/md_theme_light_errorContainer"
+                android:gravity="center"
+                android:textColor="@color/md_theme_light_onErrorContainer"
+                android:textSize="@dimen/font_medium"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/label_title_error"
+                tools:text="@string/lorem_ipsum" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_pokedex_list.xml
+++ b/app/src/main/res/layout/fragment_pokedex_list.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".features.pokedex.presentation.PokedexListFragment">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/pokedex_list"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:listitem="@layout/view_item_pokedex_pokemon" />
+        android:layout_height="wrap_content"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/pokedex_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:listitem="@layout/view_item_pokedex_pokemon" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </FrameLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -16,6 +16,10 @@
 
     </fragment>
 
+    <action
+        android:id="@+id/action_to_pokedex"
+        app:destination="@id/pokedex_fragment" />
+
     <fragment
         android:id="@+id/pokemon_detail_fragment"
         android:name="com.rafael.mardom.features.pokedex.presentation.PokemonDetailFragment"
@@ -28,13 +32,14 @@
             app:nullable="false" />
 
         <action
-            android:id="@+id/action_to_pokedex"
-            app:destination="@id/pokedex_fragment" />
-
-        <action
             android:id="@+id/action_to_pokemon_detail"
             app:destination="@id/pokemon_detail_fragment" />
     </fragment>
+
+    <fragment
+        android:id="@+id/error_fragment"
+        android:name="com.rafael.mardom.app.presentation.error.ErrorFragment"
+        tools:layout="@layout/fragment_error" />
 
     <fragment
         android:id="@+id/data_error_fragment"


### PR DESCRIPTION
## Descripción
Para la gestión de errores entre otros casos, se desea poder recargar la vista de la Pokedex. Existen muchas opciones, como un botón, por ejemplo, pero se va a añadir la funcionalidad Swipe to Refresh.
Esta funcionalidad permite al usuario deslizar el dedo desde la parte superior de la pantalla para realizar acciones como volver a ejecutar la carga de datos o navegar del error al listado.

## ¿Cómo se ha implementado?

- Se ha cambiado el contenido del fichero nav_graph.xml para incluir el fragmento de error así como separar la acción de volver a la Pokedex del fragmento de detalle. De esta manera, se puede acceder a la navegación al listado de la Pokedex desde el error.
- Se ha aprovechado para cambiar un par de detalles en el AppErrorHandler.
- Se ha actualizado el layout para error y para la lista para que la función del swipe to refresh arrope al contenido de las vistas.
- Se ha añadido la función al Fragmento y ViewModel de la Pokedex y al Fragmento del error.

## Screenshots o Vídeo
https://user-images.githubusercontent.com/104196849/233119186-b8fadfba-0b74-486b-bc2c-5c51df0a284d.mp4

https://user-images.githubusercontent.com/104196849/233119205-038255cb-ce84-4773-8b57-e9f76b9323cf.mp4


